### PR TITLE
Fix compiling error: libevent

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -1,9 +1,8 @@
 package=libevent
 $(package)_version=2.1.8
-$(package)_download_path=https://github.com/libevent/libevent/archive/
-$(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_download_file=release-$($(package)_version)-stable.tar.gz
-$(package)_sha256_hash=316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d
+$(package)_download_path=https://github.com/libevent/libevent/releases/download/release-$($(package)_version)-stable
+$(package)_file_name=$(package)-$($(package)_version)-stable.tar.gz
+$(package)_sha256_hash=965cc5a8bb46ce4199a47e9b2c9e1cae3b137e8356ffdad6d94d3b9069b71dc2
 
 define $(package)_preprocess_cmds
   ./autogen.sh


### PR DESCRIPTION
libevent doesn't seem to be available at the github archive URL. This change seems to work for me.